### PR TITLE
Fix for the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN python setup.py install
 
 # som
 WORKDIR /opt
-RUN git clone -b add/bigquery https://github.com/vsoch/som
+RUN git clone https://github.com/vsoch/som
 WORKDIR /opt/som
 RUN python setup.py install
 


### PR DESCRIPTION
This PR fix a bug during the `docker build`:

```
Step 7/13 : RUN git clone -b add/bigquery https://github.com/vsoch/som
 ---> Running in d1df9d248617
Cloning into 'som'...
fatal: Remote branch add/bigquery not found in upstream origin
The command '/bin/sh -c git clone -b add/bigquery https://github.com/vsoch/som' returned a non-zero code: 128
```

This error is due to the clone of a non existing branch (bigquery) of the som repository which has been merged into master in the commit d11633161c735b4d1ef69fe3eeeb9d2474e9c2df.
The dockerfile now target the master branch.